### PR TITLE
Convert deprecated UI dependencies to core

### DIFF
--- a/d2l-audio-mini.js
+++ b/d2l-audio-mini.js
@@ -10,8 +10,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier3-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '@d2l/media-behavior/d2l-media-behavior.js';
 import './d2l-waveform.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -20,7 +19,7 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-audio-mini">
 	<template strip-whitespace="">
-		<style include="iron-flex iron-flex-alignment d2l-typography">
+		<style include="iron-flex iron-flex-alignment">
 			:host {
 				position: relative;
 				display: inline-block;
@@ -72,7 +71,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-audio-mini">
 			}
 		</style>
 
-		<div aria-label$="[[localize('AudioPlayer')]]">
+		<div aria-label$="[[localize('AudioPlayer')]]" class="d2l-typography">
 			<d2l-waveform height-ratios="[[ waveformHeightRatios ]]" color="[[ _getWaveformColor(isPlaying) ]]"></d2l-waveform>
 
 			<audio id="media" preload="{{ _getPreload(autoLoad) }}" autoplay="{{ _getAutoplay(autoplay) }}"></audio>

--- a/d2l-audio.js
+++ b/d2l-audio.js
@@ -10,11 +10,10 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import { IronA11yKeysBehavior } from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier3-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/typography/typography.js';
 import '@d2l/media-behavior/d2l-media-behavior.js';
 import '@d2l/seek-bar/d2l-seek-bar.js';
-import 'd2l-typography/d2l-typography.js';
 import './d2l-waveform.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import './localize-behavior.js';
@@ -22,7 +21,7 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-audio">
 	<template strip-whitespace="">
-		<style include="iron-flex iron-flex-alignment d2l-typography">
+		<style include="iron-flex iron-flex-alignment">
 			:host {
 				display: inline-block;
 				width: 730px;

--- a/d2l-waveform.js
+++ b/d2l-waveform.js
@@ -1,5 +1,5 @@
 import '@polymer/polymer/polymer-legacy.js';
-import 'd2l-icons/tier3-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '@d2l/media-behavior/d2l-media-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 const $_documentContainer = document.createElement('template');

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,13 +6,13 @@
 				display: block !important;
 			}
 		</style>
-	<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 	<script type="module">
 import '../d2l-audio.js';
 </script>
 	<script type="module" src="../d2l-audio.js"></script>
   </head>
-  <body>
+  <body class="d2l-typography">
 		<d2l-audio info="Recorded May 18th, 1983" src="https://ia802508.us.archive.org/5/items/testmp3testfile/mpthreetest.mp3" auto-load></d2l-audio>
   </body>
 </html>

--- a/demo/mini.html
+++ b/demo/mini.html
@@ -6,13 +6,13 @@
 				display: block !important;
 			}
 		</style>
-	<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 	<script type="module">
 import '../d2l-audio-mini.js';
 </script>
 	<script type="module" src="../d2l-audio-mini.js"></script>
   </head>
-  <body>
+  <body class="d2l-typography">
 		<d2l-audio-mini src="https://ia802508.us.archive.org/5/items/testmp3testfile/mpthreetest.mp3" auto-load></d2l-audio-mini>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
+    "@brightspace-ui/core": "^1.53.0",
     "@d2l/media-behavior": "Brightspace/d2l-media-behavior#semver:^1",
     "@d2l/seek-bar": "Brightspace/d2l-seek-bar#semver:^1",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0",
     "@polymer/iron-flex-layout": "^3.0.0",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",


### PR DESCRIPTION
Tested in local demo, as well as in `d2l-evidence-tile`, a consumer of this component.